### PR TITLE
VDB-1137: Statediff check

### DIFF
--- a/statediff/doc.go
+++ b/statediff/doc.go
@@ -27,9 +27,12 @@ The service is spun up using the below CLI flags
 --statediff.pathsandproofs: boolean flag, tells service to generate paths and proofs for the diffed storage and state trie leaf nodes.
 --statediff.watchedaddresses: string slice flag, used to limit the state diffing process to the given addresses. Usage: --statediff.watchedaddresses=addr1 --statediff.watchedaddresses=addr2 --statediff.watchedaddresses=addr3
 
+Even though statediffs will not be processed for addresses not included in the watchedaddresses slice, an empty statediff payload still may be sent over the subscription, resulting in a "sending state diff payload to subscription" log.
+This will be addresses in a future release by filtering out empty statediff payloads.
+
 If you wish to use the websocket endpoint to subscribe to the statediff service, be sure to open up the Websocket RPC server with the `--ws` flag. The IPC-RPC server is turned on by default.
 
-The statediffing services works only with `--syncmode="full", but -importantly- does not require garbage collection to be turned off (does not require an archival node).
+The statediffing services works only with `--syncmode="full", but -importantly- does not require garbage collection to be turned off (i.e. does not require an archival node).
 
 e.g.
 


### PR DESCRIPTION
In this release, the `statediff.watchedaddresses` flag will make sure that the statediff service only processes statediffs for given contract addresses. However, there is currently no filter to make sure that the statediff Payload is not empty before sending it over the subscription. The resulting behavior is that for all blocks that don't have a state diff for the given watched contract address, we end up sending a payload with an "empty" StateDiffRlp: 
```go
{ 
   BlockNumber: 60670 
   BlockHash:[52 100 238 122 70 68 56 0 8 232 58 201 18 35 163 192 8 15 70 129 97 112 179 25 60 45 208 183 232 215 212 205]
   CreatedAccounts:[]
   DeletedAccounts:[]
   UpdatedAccounts:[]
   encoded:[]
   err:<nil>
}
```

and see a lot of `sending state diff payload to subscription...` logs, which is misleading.

This issue has been fixed in the updated approach to statediffing: https://github.com/makerdao/go-ethereum/pull/5. Not sure if it makes sense to put in the time to fix the issue here in this statediffing approach as well or just wait until we start using the updated approach. 🤔 