### PR TITLE
Allow state diff subscription

### DIFF
--- a/accounts/abi/bind/backends/simulated.go
+++ b/accounts/abi/bind/backends/simulated.go
@@ -744,6 +744,10 @@ func (fb *filterBackend) SubscribePendingLogsEvent(ch chan<- []*types.Log) event
 	return nullSubscription()
 }
 
+func (fb *filterBackend) SubscribeStateChangeEvent(ch chan<- core.StateChangeEvent) event.Subscription {
+	return nullSubscription()
+}
+
 func (fb *filterBackend) BloomStatus() (uint64, uint64) { return 4096, 0 }
 
 func (fb *filterBackend) ServiceFilter(ctx context.Context, ms *bloombits.MatcherSession) {

--- a/cmd/geth/retesteth.go
+++ b/cmd/geth/retesteth.go
@@ -686,7 +686,7 @@ func (api *RetestethAPI) AccountRange(ctx context.Context,
 			root = statedb.IntermediateRoot(vmenv.ChainConfig().IsEIP158(block.Number()))
 			if idx == int(txIndex) {
 				// This is to make sure root can be opened by OpenTrie
-				root, err = statedb.Commit(api.chainConfig.IsEIP158(block.Number()))
+				root, _, err = statedb.Commit(api.chainConfig.IsEIP158(block.Number()))
 				if err != nil {
 					return AccountRangeResult{}, err
 				}
@@ -796,7 +796,7 @@ func (api *RetestethAPI) StorageRangeAt(ctx context.Context,
 			_ = statedb.IntermediateRoot(vmenv.ChainConfig().IsEIP158(block.Number()))
 			if idx == int(txIndex) {
 				// This is to make sure root can be opened by OpenTrie
-				_, err = statedb.Commit(vmenv.ChainConfig().IsEIP158(block.Number()))
+				_, _, err = statedb.Commit(vmenv.ChainConfig().IsEIP158(block.Number()))
 				if err != nil {
 					return StorageRangeResult{}, err
 				}

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -2463,6 +2463,7 @@ func (bc *BlockChain) SubscribeBlockProcessingEvent(ch chan<- bool) event.Subscr
 	return bc.scope.Track(bc.blockProcFeed.Subscribe(ch))
 }
 
-func (bc *BlockChain) SubscribeStateChangeEvents(ch chan<- StateChangeEvent) event.Subscription {
+// SubscribeStateChangeEvent registers a subscription StateChangeEvent.
+func (bc *BlockChain) SubscribeStateChangeEvent(ch chan<- StateChangeEvent) event.Subscription {
 	return bc.scope.Track(bc.stateChangeEventFeed.Subscribe(ch))
 }

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1434,10 +1434,13 @@ func (bc *BlockChain) writeBlockWithState(block *types.Block, receipts []*types.
 		log.Crit("Failed to write block into disk", "err", err)
 	}
 	// Commit all cached state changes into underlying memory database.
-	root, err := state.Commit(bc.chainConfig.IsEIP158(block.Number()))
-	if err != nil {
-		return NonStatTy, err
+	root, stateChanges, commitErr := state.Commit(bc.chainConfig.IsEIP158(block.Number()))
+	log.Debug("StateChanges", "count", len(stateChanges))
+
+	if commitErr != nil {
+		return NonStatTy, commitErr
 	}
+
 	triedb := bc.stateCache.TrieDB()
 
 	// If we're running an archive node, always flush

--- a/core/blockchain_test.go
+++ b/core/blockchain_test.go
@@ -3048,7 +3048,7 @@ func testSendingStateChangeEvents(t *testing.T, numberOfEventsToSend int) {
 	defer blockchain.Stop()
 
 	stateChangeCh := make(chan StateChangeEvent)
-	blockchain.SubscribeStateChangeEvents(stateChangeCh)
+	blockchain.SubscribeStateChangeEvent(stateChangeCh)
 
 	// create numberOfEventsToSend blocks that include State Changes
 	chain, _ := GenerateChain(params.TestChainConfig, genesis, ethash.NewFaker(), db, numberOfEventsToSend, func(i int, block *BlockGen) {

--- a/core/chain_makers.go
+++ b/core/chain_makers.go
@@ -216,7 +216,7 @@ func GenerateChain(config *params.ChainConfig, parent *types.Block, engine conse
 			block, _ := b.engine.FinalizeAndAssemble(chainreader, b.header, statedb, b.txs, b.uncles, b.receipts)
 
 			// Write state changes to db
-			root, err := statedb.Commit(config.IsEIP158(b.header.Number))
+			root, _, err := statedb.Commit(config.IsEIP158(b.header.Number))
 			if err != nil {
 				panic(fmt.Sprintf("state write error: %v", err))
 			}

--- a/core/events.go
+++ b/core/events.go
@@ -18,6 +18,7 @@ package core
 
 import (
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/types"
 )
 
@@ -34,6 +35,11 @@ type ChainEvent struct {
 	Block *types.Block
 	Hash  common.Hash
 	Logs  []*types.Log
+}
+
+type StateChangeEvent struct {
+	*types.Block
+	state.StateChanges
 }
 
 type ChainSideEvent struct {

--- a/core/state/state_test.go
+++ b/core/state/state_test.go
@@ -167,7 +167,7 @@ func TestSnapshot2(t *testing.T) {
 	so0.deleted = false
 	state.setStateObject(so0)
 
-	root, _ := state.Commit(false)
+	root, _, _ := state.Commit(false)
 	state.Reset(root)
 
 	// and one with deleted == true

--- a/core/state/sync_test.go
+++ b/core/state/sync_test.go
@@ -62,7 +62,7 @@ func makeTestState() (Database, common.Hash, []*testAccount) {
 		state.updateStateObject(obj)
 		accounts = append(accounts, acc)
 	}
-	root, _ := state.Commit(false)
+	root, _, _ := state.Commit(false)
 
 	// Return the generated state
 	return db, root, accounts

--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -220,6 +220,10 @@ func (b *EthAPIBackend) SubscribeLogsEvent(ch chan<- []*types.Log) event.Subscri
 	return b.eth.BlockChain().SubscribeLogsEvent(ch)
 }
 
+func (b *EthAPIBackend) SubscribeStateChangeEvent(ch chan<- core.StateChangeEvent) event.Subscription {
+	return b.eth.BlockChain().SubscribeStateChangeEvent(ch)
+}
+
 func (b *EthAPIBackend) SendTx(ctx context.Context, signedTx *types.Transaction) error {
 	return b.eth.txPool.AddLocal(signedTx)
 }

--- a/eth/api_tracer.go
+++ b/eth/api_tracer.go
@@ -295,7 +295,7 @@ func (api *PrivateDebugAPI) traceChain(ctx context.Context, start, end *types.Bl
 				break
 			}
 			// Finalize the state so any modifications are written to the trie
-			root, err := statedb.Commit(api.eth.blockchain.Config().IsEIP158(block.Number()))
+			root, _, err := statedb.Commit(api.eth.blockchain.Config().IsEIP158(block.Number()))
 			if err != nil {
 				failed = err
 				break
@@ -681,7 +681,7 @@ func (api *PrivateDebugAPI) computeStateDB(block *types.Block, reexec uint64) (*
 			return nil, fmt.Errorf("processing block %d failed: %v", block.NumberU64(), err)
 		}
 		// Finalize the state so any modifications are written to the trie
-		root, err := statedb.Commit(api.eth.blockchain.Config().IsEIP158(block.Number()))
+		root, _, err := statedb.Commit(api.eth.blockchain.Config().IsEIP158(block.Number()))
 		if err != nil {
 			return nil, err
 		}

--- a/eth/filters/filter.go
+++ b/eth/filters/filter.go
@@ -42,6 +42,7 @@ type Backend interface {
 	SubscribeRemovedLogsEvent(ch chan<- core.RemovedLogsEvent) event.Subscription
 	SubscribeLogsEvent(ch chan<- []*types.Log) event.Subscription
 	SubscribePendingLogsEvent(ch chan<- []*types.Log) event.Subscription
+	SubscribeStateChangeEvent(ch chan<- core.StateChangeEvent) event.Subscription
 
 	BloomStatus() (uint64, uint64)
 	ServiceFilter(ctx context.Context, session *bloombits.MatcherSession)

--- a/eth/filters/filter_system_test.go
+++ b/eth/filters/filter_system_test.go
@@ -47,6 +47,7 @@ type testBackend struct {
 	rmLogsFeed      event.Feed
 	pendingLogsFeed event.Feed
 	chainFeed       event.Feed
+	stateChangeFeed event.Feed
 }
 
 func (b *testBackend) ChainDb() ethdb.Database {
@@ -119,6 +120,10 @@ func (b *testBackend) SubscribePendingLogsEvent(ch chan<- []*types.Log) event.Su
 
 func (b *testBackend) SubscribeChainEvent(ch chan<- core.ChainEvent) event.Subscription {
 	return b.chainFeed.Subscribe(ch)
+}
+
+func (b *testBackend) SubscribeStateChangeEvent(ch chan<- core.StateChangeEvent) event.Subscription {
+	return b.stateChangeFeed.Subscribe(ch)
 }
 
 func (b *testBackend) BloomStatus() (uint64, uint64) {

--- a/eth/filters/statediff.go
+++ b/eth/filters/statediff.go
@@ -1,0 +1,113 @@
+package filters
+
+import (
+	"math/big"
+	"reflect"
+
+	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core"
+	"github.com/ethereum/go-ethereum/core/state"
+	"github.com/ethereum/go-ethereum/rlp"
+)
+
+var emptyPayload Payload
+
+// processStateChanges builds the state diff Payload from the modified accounts in the StateChangeEvent
+func processStateChanges(event core.StateChangeEvent, crit ethereum.FilterQuery) (Payload, error) {
+	var accountDiffs []AccountDiff
+	block := event.Block
+	// Iterate over state changes to build AccountDiffs
+	for addr, modifiedAccount := range event.StateChanges {
+		if len(crit.Addresses) > 0 && !includes(crit.Addresses, addr) {
+			continue
+		}
+
+		a, err := buildAccountDiff(addr, modifiedAccount)
+		if err != nil {
+			return emptyPayload, err
+		}
+
+		accountDiffs = append(accountDiffs, a)
+	}
+
+	if len(accountDiffs) == 0 {
+		return emptyPayload, nil
+	}
+
+	stateDiff := StateDiff{
+		BlockNumber:     block.Number(),
+		BlockHash:       block.Hash(),
+		UpdatedAccounts: accountDiffs,
+	}
+
+	stateDiffRlp, err := rlp.EncodeToBytes(stateDiff)
+	if err != nil {
+		return emptyPayload, err
+	}
+	payload := Payload{
+		StateDiffRlp: stateDiffRlp,
+	}
+
+	return payload, nil
+}
+
+// buildAccountDiff
+func buildAccountDiff(addr common.Address, modifiedAccount state.ModifiedAccount) (AccountDiff, error) {
+	emptyAccountDiff := AccountDiff{}
+	accountBytes, err := rlp.EncodeToBytes(modifiedAccount.Account)
+	if err != nil {
+		return emptyAccountDiff, err
+	}
+
+	var storageDiffs []StorageDiff
+	for k, v := range modifiedAccount.Storage {
+		// Storage diff value should be an RLP object too
+		encodedValueRlp, err := rlp.EncodeToBytes(v[:])
+		if err != nil {
+			return emptyAccountDiff, err
+		}
+		storageKey := k
+		diff := StorageDiff{
+			Key:   storageKey[:],
+			Value: encodedValueRlp,
+		}
+		storageDiffs = append(storageDiffs, diff)
+	}
+
+	address := addr
+	return AccountDiff{
+		Key:     address[:],
+		Value:   accountBytes,
+		Storage: storageDiffs,
+	}, nil
+}
+
+func isPayloadEmpty(payload Payload) bool {
+	return reflect.DeepEqual(payload, emptyPayload)
+}
+
+// Payload packages the data to send to statediff subscriptions
+type Payload struct {
+	StateDiffRlp []byte `json:"stateDiff"    gencodec:"required"`
+}
+
+// StateDiff is the final output structure from the builder
+type StateDiff struct {
+	BlockNumber     *big.Int      `json:"blockNumber"     gencodec:"required"`
+	BlockHash       common.Hash   `json:"blockHash"       gencodec:"required"`
+	UpdatedAccounts []AccountDiff `json:"updatedAccounts" gencodec:"required"`
+}
+
+// AccountDiff holds the data for a single state diff node
+type AccountDiff struct {
+	Key     []byte        `json:"key"         gencodec:"required"`
+	Value   []byte        `json:"value"       gencodec:"required"`
+	Storage []StorageDiff `json:"storage"     gencodec:"required"`
+}
+
+// StorageDiff holds the data for a single storage diff node
+type StorageDiff struct {
+	Key   []byte `json:"key"         gencodec:"required"`
+	Value []byte `json:"value"       gencodec:"required"`
+}

--- a/ethclient/ethclient.go
+++ b/ethclient/ethclient.go
@@ -28,6 +28,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/eth/filters"
 	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/ethereum/go-ethereum/rpc"
 )
@@ -369,6 +370,15 @@ func (ec *Client) NonceAt(ctx context.Context, account common.Address, blockNumb
 	var result hexutil.Uint64
 	err := ec.c.CallContext(ctx, &result, "eth_getTransactionCount", account, toBlockNumArg(blockNumber))
 	return uint64(result), err
+}
+
+// SubscribeNewStateChanges subscribes to notifications about the state change events on the given channel.
+func (ec *Client) SubscribeNewStateChanges(ctx context.Context, q ethereum.FilterQuery, ch chan<- filters.Payload) (ethereum.Subscription, error) {
+	arg, err := toFilterArg(q)
+	if err != nil {
+		return nil, err
+	}
+	return ec.c.EthSubscribe(ctx, ch, "newStateChanges", arg)
 }
 
 // Filters

--- a/internal/ethapi/backend.go
+++ b/internal/ethapi/backend.go
@@ -63,6 +63,7 @@ type Backend interface {
 	SubscribeChainEvent(ch chan<- core.ChainEvent) event.Subscription
 	SubscribeChainHeadEvent(ch chan<- core.ChainHeadEvent) event.Subscription
 	SubscribeChainSideEvent(ch chan<- core.ChainSideEvent) event.Subscription
+	SubscribeStateChangeEvent(ch chan<- core.StateChangeEvent) event.Subscription
 
 	// Transaction pool API
 	SendTx(ctx context.Context, signedTx *types.Transaction) error

--- a/les/api_backend.go
+++ b/les/api_backend.go
@@ -234,6 +234,10 @@ func (b *LesApiBackend) SubscribeRemovedLogsEvent(ch chan<- core.RemovedLogsEven
 	return b.eth.blockchain.SubscribeRemovedLogsEvent(ch)
 }
 
+func (b *LesApiBackend) SubscribeStateChangeEvent(ch chan<- core.StateChangeEvent) event.Subscription {
+	return b.eth.blockchain.SubscribeStateChangeEvent(ch)
+}
+
 func (b *LesApiBackend) Downloader() *downloader.Downloader {
 	return b.eth.Downloader()
 }

--- a/light/lightchain.go
+++ b/light/lightchain.go
@@ -557,6 +557,12 @@ func (lc *LightChain) SubscribeRemovedLogsEvent(ch chan<- core.RemovedLogsEvent)
 	return lc.scope.Track(new(event.Feed).Subscribe(ch))
 }
 
+// SubscribeStateChangeEvent implements the interface of filters.Backend
+// LightChain does not send core.StateChangeEvent, so return an empty subscription.
+func (lc *LightChain) SubscribeStateChangeEvent(ch chan<- core.StateChangeEvent) event.Subscription {
+	return lc.scope.Track(new(event.Feed).Subscribe(ch))
+}
+
 // DisableCheckFreq disables header validation. This is used for ultralight mode.
 func (lc *LightChain) DisableCheckFreq() {
 	atomic.StoreInt32(&lc.disableCheckFreq, 1)

--- a/tests/state_test_util.go
+++ b/tests/state_test_util.go
@@ -218,7 +218,7 @@ func MakePreState(db ethdb.Database, accounts core.GenesisAlloc, snapshotter boo
 		}
 	}
 	// Commit and re-open to start with a clean state.
-	root, _ := statedb.Commit(false)
+	root, _, _ := statedb.Commit(false)
 
 	var snaps *snapshot.Tree
 	if snapshotter {


### PR DESCRIPTION
This PR allows for a client to subscribe to Account state and storage changes for each block. It is also possible to filter by contract address(es), so that only changes for given contracts are sent.

- As `StateDB.Commit` is writing the state to the underlying in-memory database, it now also returns the state changes that were made, as a map: `map[common.Address]ModifiedAccount`.  This data structure is called `StateChanges`. The `ModifiedAccount` includes the Account and it’s Storage trie that has changed in the current block.
- The `StateChanges` are [sent](https://github.com/makerdao/go-ethereum/blob/allow-state-diff-subscription/core/blockchain.go#L1440) to an `event.Feed` along with the current block as a `StateChangeEvent`.
- Following a similar pattern that is used for subscribing to new Log events, the `filter.EventSystem` [subscribes](https://github.com/makerdao/go-ethereum/blob/allow-state-diff-subscription/eth/filters/filter_system.go#L140) to new `StateChangeEvent`s.
- `StateChangeEvent`s  are [processed](https://github.com/makerdao/go-ethereum/blob/allow-state-diff-subscription/eth/filters/statediff.go), by being turned into `StateDiff`structs and then RLP encoded.
- The `filter.EventSystem` [sends](https://github.com/makerdao/go-ethereum/blob/allow-state-diff-subscription/eth/filters/filter_system.go#L411) these payloads to the StateChange subscription: 
- To subscribe to these state change payloads:
```
rpcClient, _ := ethclient.Dial("ethNodeUrl")
ethClient := ethclient.NewClient(rpcClient)
filterCriteria := ethereum.FilterQuery{
	Addresses: []common.Address{},
}
payloadChan := make(chan filters.Payload)

ethClient.SubscribeNewStateChanges(context.Background(), filterCriteria, payloadChan)
```

Notes:
- `filters.processStateChanges` can be updated to also filter by block number.
- One piece that we’d love some feedback/input on is whether looking at [`stateObject.originStorage`](https://github.com/makerdao/go-ethereum/blob/allow-state-diff-subscription/core/state/state_object.go#L82) alone is sufficient for [detecting a state change](https://github.com/makerdao/go-ethereum/blob/allow-state-diff-subscription/core/state/statedb.go#L839). Or, if we would also want to look at [`pendingStorage`](https://github.com/makerdao/go-ethereum/blob/allow-state-diff-subscription/core/state/state_object.go#L83) to ensure that StateChanges only includes **diffs** between blocks.  

