### PR TITLE
VDB-1523: Track diffStorage for accurate stateDiffs

### DIFF
--- a/core/state/state_object.go
+++ b/core/state/state_object.go
@@ -81,6 +81,7 @@ type stateObject struct {
 
 	originStorage  Storage // Storage cache of original entries to dedup rewrites, reset for every transaction
 	pendingStorage Storage // Storage entries that need to be flushed to disk, at the end of an entire block
+	diffStorage    Storage // Storage entries that need to be emitted with stateDiffs
 	dirtyStorage   Storage // Storage entries that have been modified in the current transaction execution
 	fakeStorage    Storage // Fake storage which constructed by caller for debugging purpose.
 
@@ -125,6 +126,7 @@ func newObject(db *StateDB, address common.Address, data Account) *stateObject {
 		originStorage:  make(Storage),
 		pendingStorage: make(Storage),
 		dirtyStorage:   make(Storage),
+		diffStorage:    make(Storage),
 	}
 }
 
@@ -321,6 +323,7 @@ func (s *stateObject) updateTrie(db Database) Trie {
 			continue
 		}
 		s.originStorage[key] = value
+		s.diffStorage[key] = value
 
 		var v []byte
 		if (value == common.Hash{}) {
@@ -423,6 +426,7 @@ func (s *stateObject) deepCopy(db *StateDB) *stateObject {
 	stateObject.dirtyStorage = s.dirtyStorage.Copy()
 	stateObject.originStorage = s.originStorage.Copy()
 	stateObject.pendingStorage = s.pendingStorage.Copy()
+	stateObject.diffStorage = s.diffStorage.Copy()
 	stateObject.suicided = s.suicided
 	stateObject.dirtyCode = s.dirtyCode
 	stateObject.deleted = s.deleted

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -835,8 +835,9 @@ func (s *StateDB) Commit(deleteEmptyObjects bool) (common.Hash, StateChanges, er
 
 			// Add the account to the modifiedAccounts map
 			modifiedAccount = ModifiedAccount{Account: obj.data}
-			// Add the origin storage to the modifiedAccounts map before it's committed (and flushed from in-memory)
-			modifiedAccount.Storage = obj.originStorage
+			// Add the diff storage to the modifiedAccounts map
+			modifiedAccount.Storage = obj.diffStorage
+			obj.diffStorage = make(Storage)
 
 			// Write any storage changes in the state object to its storage trie
 			if err := obj.CommitTrie(s.db); err != nil {


### PR DESCRIPTION
This PR is cherry-picking [376738fdd5ca8f0e0c96b2f59432c0a9e510f13a](https://github.com/makerdao/go-ethereum/commit/376738fdd5ca8f0e0c96b2f59432c0a9e510f13a) from the work that Eric did to not send duplicate diffs in our geth patch.